### PR TITLE
feat(coding-standard): add autopep8 and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+;
+; Global Editor Config
+;
+; This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+;
+; Top level editor config.
+root = true
+
+; Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+; Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+; YAML format, 2 spaces
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+; Makefile is indented with tabs
+[Makefile]
+indent_style = tab

--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -1,28 +1,26 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# For more information see: https://docs.github.com/en/actions/tutorials/build-and-test-code/python
 
-name: Software Test
+name: Check coding standard
 
 on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version:  ${{ matrix.python-version }}
+        python-version: "3.x"
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-    - name: Run Tests
+    - name: Lint files
       run: |
-        pytest --doctest-modules --cov=dapytains --verbose
+        autopep8 -v --diff --exit-code --recursive dapytains tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+    - name: Lint files
+      run: |
+        autopep8 --diff --exit-code --recursive dapytains tests
     - name: Run Tests
       run: |
         pytest --doctest-modules --cov=dapytains --verbose

--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,2 @@
+[pycodestyle]
+max_line_length = 128

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 include .env.local
 
+AUTOPEP8        ?= autopep8
 COMPOSE_FILE    ?= compose.yaml
 DOCKER_COMPOSE  ?= docker compose -f $(COMPOSE_FILE)
 PIP             ?= pip
@@ -20,7 +21,7 @@ ifeq ($(COLOR_SUPPORT),1)
 	COLOR_END    = \033[0m
 endif
 
-.PHONY: help install start test docker-shell docker-start docker-stop
+.PHONY: help install lint lint-autopep8 lint-fix lint-fix-autopep8 start test docker-shell docker-start docker-stop
 
 help:
 	@echo "$(COLOR_YELLOW)Usage:$(COLOR_END)"
@@ -29,20 +30,35 @@ help:
 	@echo "$(COLOR_YELLOW)Example:$(COLOR_END)"
 	@echo "  make start VERBOSE=1"
 	@echo ""
-	@echo "$(COLOR_YELLOW)Available targets:$(COLOR_END)"
-	@echo "$(COLOR_GREEN)  install     $(COLOR_END) Installs dependencies from requirements.txt"
-	@echo "$(COLOR_GREEN)  start       $(COLOR_END) Starts the web server"
-	@echo "$(COLOR_GREEN)  test        $(COLOR_END) Executes tests"
-	@echo "$(COLOR_YELLOW) docker$(COLOR_END)"
-	@echo "$(COLOR_GREEN)  docker-start$(COLOR_END) Starts docker container"
-	@echo "$(COLOR_GREEN)  docker-stop $(COLOR_END) Stops docker container"
-	@echo "$(COLOR_GREEN)  docker-shell$(COLOR_END) Opens a shell in docker container"
+	@echo "$(COLOR_YELLOW)Available targets: $(COLOR_END)"
+	@echo "$(COLOR_GREEN)  install           $(COLOR_END) Installs dependencies from requirements.txt"
+	@echo "$(COLOR_GREEN)  start             $(COLOR_END) Starts the web server"
+	@echo "$(COLOR_GREEN)  test              $(COLOR_END) Executes tests"
+	@echo "$(COLOR_YELLOW) coding standard   $(COLOR_END)"
+	@echo "$(COLOR_GREEN)  lint              $(COLOR_END) Lints files"
+	@echo "$(COLOR_GREEN)  lint-autopep8     $(COLOR_END) Lints files with autopep8"
+	@echo "$(COLOR_GREEN)  lint-fix          $(COLOR_END) Fixes files linting"
+	@echo "$(COLOR_GREEN)  lint-fix-autopep8 $(COLOR_END) Fixes files linting with autopep8"
+	@echo "$(COLOR_YELLOW) docker            $(COLOR_END)"
+	@echo "$(COLOR_GREEN)  docker-start      $(COLOR_END) Starts docker container"
+	@echo "$(COLOR_GREEN)  docker-stop       $(COLOR_END) Stops docker container"
+	@echo "$(COLOR_GREEN)  docker-shell      $(COLOR_END) Opens a shell in docker container"
 
 install:
 	$(PIP) install -r requirements.txt
 ifneq ($(SERVER_ENV),"prod")
 	$(PIP) install -r requirements-dev.txt
 endif
+
+lint: lint-autopep8
+
+lint-autopep8:
+	$(AUTOPEP8) --diff --exit-code --recursive dapytains tests
+
+lint-fix: lint-fix-autopep8
+
+lint-fix-autopep8:
+	$(AUTOPEP8) --in-place --recursive dapytains tests
 
 start:
 ifeq ($(VERBOSE),1)

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ endif
 lint: lint-autopep8
 
 lint-autopep8:
-	$(AUTOPEP8) --diff --exit-code --recursive dapytains tests
+	$(AUTOPEP8) -v --diff --exit-code --recursive dapytains tests
 
 lint-fix: lint-fix-autopep8
 
 lint-fix-autopep8:
-	$(AUTOPEP8) --in-place --recursive dapytains tests
+	$(AUTOPEP8) -v --in-place --recursive dapytains tests
 
 start:
 ifeq ($(VERBOSE),1)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-cov
 coveralls
 pytest-sugar
 requests-mock
+autopep8


### PR DESCRIPTION
# Summary

This PR installs autopep8 for linting and fixing pep8 coding standard.

## Testing

### Linting

Execute the following command:
```shell
$ make lint
```

### Fixing

Execute the following command:
```shell
$ make lint-fix
```

## TODO

Fix linting before merging.

----

This follows @Haguili's [comment](https://github.com/distributed-text-services/MyDapytains/pull/17/files#r2236376954)