### PR TITLE
(bugfix) Fix a bug where a tree where a level split in two and expect…

### DIFF
--- a/dapytains/tei/citeStructure.py
+++ b/dapytains/tei/citeStructure.py
@@ -284,12 +284,14 @@ class CiteStructureParser:
 
         unsorted = []
         for s in structure:
-            unsorted.extend(
-                [
-                    (f"{prefix}{s.delim}{value}", s)
-                    for value in xpath_proc.evaluate(f"{xpath_prefix}{s.xpath}")
-                ]
-            )
+            results = xpath_proc.evaluate(f"{xpath_prefix}{s.xpath}")
+            if results is not None:
+                unsorted.extend(
+                    [
+                        (f"{prefix}{s.delim}{value}", s)
+                        for value in results
+                    ]
+                )
 
         unsorted = [
             _simple_node(ref, self.generate_xpath(ref), struct)

--- a/tests/tei/uneven_parent_level.xml
+++ b/tests/tei/uneven_parent_level.xml
@@ -1,0 +1,41 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <encodingDesc>
+            <refsDecl>
+                <citeStructure unit="book" match="//body/div" use="@n">
+                    <citeStructure unit="verse" match="ab" use="position()" delim=":"/>
+                    <citeStructure unit="chapter" match="div" use="position()" delim=" ">
+                        <citeStructure unit="bloup" match="l" use="position()" delim="#"/>
+                    </citeStructure>
+                </citeStructure>
+            </refsDecl>
+        </encodingDesc>
+    </teiHeader>
+    <text>
+    <body>
+    <div n="Luke">
+        <div>
+            <l>Text 1</l>
+        </div>
+        <ab>
+            <l>Text 2</l>
+            <l>Text 3</l>
+        </ab>
+    </div>
+    <div n="Mark">
+        <ab>
+            <div>Text A</div>
+            <div>Text B</div>
+            <l>Text C</l>
+            <div>Text D</div>
+        </ab>
+        <ab>
+            <div>Text A</div>
+            <div>Text B</div>
+            <l>Text C</l>
+            <div>Text D</div>
+        </ab>
+    </div>
+    </body>
+    </text>
+</TEI>

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -1,6 +1,8 @@
 import os.path
 
 import pytest
+
+from dapytains.tei.citeStructure import CitableUnit
 from dapytains.tei.document import Document
 from lxml.etree import tostring
 
@@ -252,3 +254,16 @@ def test_xml_entity():
  '    </text>\n'
  '</TEI>')
 
+
+def _flat_refs(refs: list[CitableUnit]) -> list[str]:
+    data = []
+    for ref in refs:
+        data.append(ref.ref)
+        data.extend(_flat_refs(ref.children))
+    return data
+
+
+def test_ref_parsing_uneven_tree():
+    """Test that a level that can contain data is not missed"""
+    doc = Document(f"{local_dir}/uneven_parent_level.xml")
+    assert _flat_refs(doc.get_reffs()) == ['Luke', 'Luke 1', 'Luke 1#1', 'Luke:1', 'Mark', 'Mark:1', 'Mark:2']


### PR DESCRIPTION
… descendants would lead to None != iterable